### PR TITLE
Add install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 <a href="https://forum.quasar.dev" target="_blank"><img src="https://img.shields.io/badge/community-forum-brightgreen.svg"></a>
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 
+## Install
+
+To add this extension to your quasar project, run the following command.
+```console
+quasar ext add @quasar/icon-genie
+```
+
 ## What is Icon Genie
 
 This node module outputs a set of **SQUARE** favicons, webicons, pwa-icons and electron-icons as well as iOS, Windows Store and MacOS icons from an original 1240x1240 square icon that retains transparency and also **minifies** the assets. It will also create splash screens for Cordova/Capacitor and even a minified svg.


### PR DESCRIPTION
Getting the install command is not as straight forward as it should be, coming from quasar docs many pages will send you to the github repo without install instructions,  only the link at the top of the repository desc leads to a quasar doc page with the install command. IMHO it would be easier for newer (and experienced users like me who don't remember the commands) to show the install instructions on the readme like many other npm, composer, etc packages do